### PR TITLE
Fix linux-x64 path when executing as a dotnet tool.

### DIFF
--- a/pack/tools/net6.0/any/DotnetToolWrapper.json
+++ b/pack/tools/net6.0/any/DotnetToolWrapper.json
@@ -3,6 +3,6 @@
     "program": "../../../win-x64/pandoc.exe"
   },
   "linux-x64": {
-    "program": "../../../linux-x64/bin/pandoc"
+    "program": "../../../linux-x64/pandoc"
   }
 }

--- a/pack/tools/net8.0/any/DotnetToolWrapper.json
+++ b/pack/tools/net8.0/any/DotnetToolWrapper.json
@@ -3,6 +3,6 @@
     "program": "../../../win-x64/pandoc.exe"
   },
   "linux-x64": {
-    "program": "../../../linux-x64/bin/pandoc"
+    "program": "../../../linux-x64/pandoc"
   }
 }


### PR DESCRIPTION
This PR fixes the linux path when executing as a dotnet tool.